### PR TITLE
ボタン配置

### DIFF
--- a/client/ActionStats/Base.lproj/Main.storyboard
+++ b/client/ActionStats/Base.lproj/Main.storyboard
@@ -22,32 +22,42 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="8tZ-fj-2lw">
-                                <rect key="frame" x="67" y="69" width="240" height="483"/>
+                                <rect key="frame" x="16" y="64" width="343" height="471"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="XKE-Vb-2oP">
-                                    <size key="itemSize" width="50" height="50"/>
+                                    <size key="itemSize" width="148" height="25"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="OutcomeCell" id="7Bf-cA-JPr">
-                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="140" height="25"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                                            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="140" height="25"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </view>
+                                        <size key="customSize" width="140" height="25"/>
                                     </collectionViewCell>
                                 </cells>
                                 <connections>
                                     <outlet property="dataSource" destination="BYZ-38-t0r" id="0wY-Dn-qwz"/>
                                 </connections>
                             </collectionView>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RmY-Pd-FVc">
+                                <rect key="frame" x="124" y="556" width="126" height="49"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" red="1" green="0.83396322561485903" blue="0.50058067946818496" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <state key="normal" title="Button"/>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
+                    <connections>
+                        <outlet property="nextButton" destination="RmY-Pd-FVc" id="UfW-Ry-bdK"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/client/ActionStats/ViewController.swift
+++ b/client/ActionStats/ViewController.swift
@@ -4,21 +4,26 @@ class ViewController: UIViewController, UICollectionViewDelegate, UICollectionVi
     
     var myCollectionView : UICollectionView!
 
+    @IBOutlet weak var nextButton: UIButton!
+
     var outcomes: Array<[String: Any]> = []
 
     override func viewDidLoad() {
         loadOutcomes()
 
         super.viewDidLoad()
+
         // Do any additional setup after loading the view, typically from a nib.
 
         // Generate layout of CollectionView
         let layout = UICollectionViewFlowLayout()
 
         // Size of cell
+        // not work
         layout.itemSize = CGSize(width: 120, height: 50)
 
         // Margin of cell
+        // not work
         layout.sectionInset = UIEdgeInsets(top: 16, left: 16, bottom: 32, right: 16)
 
         // Generate CollectionView
@@ -32,7 +37,6 @@ class ViewController: UIViewController, UICollectionViewDelegate, UICollectionVi
         while(outcomes.count == 0) {
             sleep(1)
         }
-        self.view.addSubview(myCollectionView)
     }
 
     override func didReceiveMemoryWarning() {


### PR DESCRIPTION
```
# 画面上で使用されているCollectionViewの四角の枠をUICollectionViewFlowLayout()としてコード上で設定できるようにする
let layout = UICollectionViewFlowLayout()
	
# self.viewの最上面にセット => 他の部品が下に隠れてしまってる
self.view.addSubview(myCollectionView)

# これが適用されないのが謎	
layout.itemSize = CGSize(width: 120, height: 50)
layout.sectionInset = UIEdgeInsets(top: 16, left: 16, bottom: 32, right: 16)
```